### PR TITLE
Fix functional component type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,7 +97,7 @@ export interface ComponentProps extends ComponentPropsBase {
   ref?: React.MutableRefObject<React.ComponentClass>
 }
 
-export type ReactComponent = React.ComponentClass | string | React.SFC<ComponentProps>;
+export type ReactComponent = React.ComponentClass | string | React.FC<ComponentProps>;
 
 export interface HotKeysProps extends HotKeysEnabledProps {
   /**


### PR DESCRIPTION
There's seems to be a typo in the TypeScript definitions, making it unusable. There's no `React.SFC`. The correct type is `React.FC`.

Without this fix, the following error occurs with TypeScript:

```
     99 |
  > 100 | eact.SFC<ComponentProps>;
  >     |      ^^^^ Namespace 'React' has no exported member 'SFC'.
    101 |
    102 | export interface HotKeysProps extends HotKeysEnabledP
```